### PR TITLE
Dialog tree widget consistency

### DIFF
--- a/src/FileAgeStatsWindow.h
+++ b/src/FileAgeStatsWindow.h
@@ -16,15 +16,14 @@
 #include <QTreeWidgetItem>
 
 #include "ui_file-age-stats-window.h"
-#include "FileAgeStats.h" // YearsList
 #include "Subtree.h"
+#include "Typedefs.h" // FileSize
 
 
 namespace QDirStat
 {
-    class FileAgeStats;
-    class PercentBarDelegate;
     class YearListItem;
+    class YearStats;
 
     /**
      * Modeless dialog to display file age statistics, i.e. statistics about
@@ -35,7 +34,7 @@ namespace QDirStat
 	Q_OBJECT
 
 	/**
-	 * Constructor.  Private.  Access the window through the static
+	 * Constructor.  Private; access the window through the static
 	 * populateSharedInstance().
 	 *
 	 * Note that this widget will destroy itself upon window close.
@@ -48,7 +47,7 @@ namespace QDirStat
 	~FileAgeStatsWindow() override;
 
 	/**
-	 * Returns the shared instance pointer for this windw.  It is created if
+	 * Returns the shared instance pointer for this window.  It is created if
 	 * it doesn't already exist.
 	 **/
 	static FileAgeStatsWindow * sharedInstance( QWidget * parent );
@@ -60,8 +59,8 @@ namespace QDirStat
 	 * Convenience function for creating, populating and showing the shared
 	 * instance.
 	 **/
-	static void populateSharedInstance( QWidget  * parent,
-	                                    FileInfo * fileInfo );
+	static void populateSharedInstance( QWidget * parent, FileInfo * fileInfo )
+	    { if ( fileInfo ) sharedInstance( parent )->populate( fileInfo ); }
 
 
     protected slots:
@@ -117,16 +116,6 @@ namespace QDirStat
 	void populate( FileInfo * fileInfo );
 
 	/**
-	 * Create an item in the years tree / list widget for each year
-	 **/
-	void populateListWidget( FileInfo * fileInfo );
-
-	/**
-	 * Fill the gaps between years.
-	 **/
-	void fillGaps( const FileAgeStats & stats );
-
-	/**
 	 * Return the currently selected item in the tree widget or 0
 	 * if there is none or if it is the wrong type.
 	 **/
@@ -153,15 +142,9 @@ namespace QDirStat
 
     private:
 
-	//
-	// Data members
-	//
-
 	std::unique_ptr<Ui::FileAgeStatsWindow> _ui;
 
-	PercentBarDelegate * _filesPercentBarDelegate{ nullptr };
-	PercentBarDelegate * _sizePercentBarDelegate{ nullptr };
-	Subtree              _subtree;
+	Subtree _subtree;
 
     };	// class FileAgeStatsWindow
 
@@ -171,14 +154,14 @@ namespace QDirStat
      **/
     enum YearListColumns
     {
-	YearListYearCol,
-	YearListFilesCountCol,
-	YearListFilesPercentBarCol,
-	YearListFilesPercentCol,
-	YearListSizeCol,
-	YearListSizePercentBarCol,
-	YearListSizePercentCol,
-	YearListColumnCount
+	YL_YearCol,
+	YL_FilesCountCol,
+	YL_FilesPercentBarCol,
+	YL_FilesPercentCol,
+	YL_SizeCol,
+	YL_SizePercentBarCol,
+	YL_SizePercentCol,
+	YL_ColumnCount,
     };
 
 
@@ -193,7 +176,7 @@ namespace QDirStat
 	/**
 	 * Constructor.
 	 **/
-	YearListItem( const YearStats & yearStats );
+	YearListItem( const YearStats & yearStats, bool enabled );
 
 	/**
 	 * Return the year for this item.
@@ -220,27 +203,16 @@ namespace QDirStat
 	 **/
 	bool operator<( const QTreeWidgetItem & other ) const override;
 
-	/**
-	 * Helper function to set both the column text and alignment.
-	 **/
-	void set( YearListColumns col, Qt::Alignment alignment, const QString & text )
-	{
-	    setText( col, text );
-	    setTextAlignment( col, Qt::AlignVCenter | alignment );
-	}
-
 
     private:
 
 	short    _year;
 	short    _month;
 	int      _filesCount;
-	float    _filesPercent;
 	FileSize _size;
-	float    _sizePercent;
 
     };	// class YearListItem
 
 }	// namespace QDirStat
 
-#endif // FileAgeStatsWindow_h
+#endif	// FileAgeStatsWindow_h

--- a/src/FileSizeStatsWindow.h
+++ b/src/FileSizeStatsWindow.h
@@ -17,7 +17,7 @@
 #include <QDialog>
 
 #include "ui_file-size-stats-window.h"
-
+#include "Subtree.h"
 
 namespace QDirStat
 {
@@ -63,10 +63,20 @@ namespace QDirStat
 	 **/
 	static void populateSharedInstance( QWidget       * mainWindow,
 	                                    FileInfo      * fileInfo,
-	                                    const QString & suffix = QString{} );
+	                                    const QString & suffix = QString{} )
+	    { if ( fileInfo ) sharedInstance( mainWindow )->populate( fileInfo, suffix ); }
 
 
     protected slots:
+
+	/**
+	 * Re-populate with the existing subtree, suffix, and dialog
+	 * settings.  This is used when excludeSymLinks is changed.
+	 * The statistics are reloaded, the buckets are re-filled,
+	 * the models are all reset, and the histogram is rebuilt,
+	 * but the percentile range is not changed.
+	 **/
+	void refresh();
 
 	/**
 	 * Load the nominal percentiles label and reset the model with the
@@ -145,9 +155,23 @@ namespace QDirStat
 	void connectActions();
 
 	/**
-	 * Populate with new content.
+	 * Populate with new content.  The titles are initialised, the
+	 * statistics are loaded, the buckets are filled, the models
+	 * are all reset, the percentile range is set automatically,
+	 * and the histogram is rebuilt.
 	 **/
 	void populate( FileInfo * fileInfo, const QString & suffix );
+
+	/**
+	 * (Re-)load the statistics from disk, including calculating
+	 * the percentiles.  Notify the models and reset the percentile
+	 * table model.
+	 *
+	 * Note that the buckets are not filled, the buckets table
+	 * model is not reset, and the histogram is not rebuilt.  These
+	 * must all be done immediately after a call to loadStats().
+	 **/
+	void loadStats( FileInfo * fileInfo, const QString & suffix );
 
 	/**
 	 * Initialise the histogram data.
@@ -184,15 +208,14 @@ namespace QDirStat
 
     private:
 
-	//
-	// Data members
-	//
-
 	std::unique_ptr<Ui::FileSizeStatsWindow> _ui;
 	std::unique_ptr<FileSizeStats>           _stats;
 
-    }; // class FileSizeStatsWindow
+	Subtree _subtree;
+	QString _suffix;
 
-} // namespace QDirStat
+    };	// class FileSizeStatsWindow
 
-#endif // FileSizeStatsWindow_h
+}	// namespace QDirStat
+
+#endif	// FileSizeStatsWindow_h

--- a/src/FileTypeStatsWindow.h
+++ b/src/FileTypeStatsWindow.h
@@ -63,8 +63,8 @@ namespace QDirStat
 	 * Convenience function for creating, populating and showing the shared
 	 * instance.
 	 **/
-	static void populateSharedInstance( QWidget  * mainWindow,
-	                                    FileInfo * subtree );
+	static void populateSharedInstance( QWidget  * mainWindow, FileInfo * subtree )
+	    { if ( subtree ) sharedInstance( mainWindow )->populate( subtree ); }
 
 
     protected slots:
@@ -132,7 +132,7 @@ namespace QDirStat
 	 * Return the suffix of the currently selected file type or an empty
 	 * string if no suffix is selected.
 	 **/
-	QString currentSuffix() const;
+	QString currentItemSuffix() const;
 
 	/**
 	 * Key press event for detecting enter/return.
@@ -155,15 +155,11 @@ namespace QDirStat
 
     private:
 
-	//
-	// Data members
-	//
-
 	std::unique_ptr<Ui::FileTypeStatsWindow> _ui;
 	Subtree _subtree;
 	int     _topX;
 
-    }; // class FileTypeStatsWindow
+    };	// class FileTypeStatsWindow
 
 
     /**
@@ -175,7 +171,7 @@ namespace QDirStat
 	FT_CountCol,
 	FT_TotalSizeCol,
 	FT_PercentageCol,
-	FT_ColumnCount
+	FT_ColumnCount,
     };
 
 
@@ -197,26 +193,8 @@ namespace QDirStat
 	              FileSize        totalSize,
 	              float           percentage );
 
-	//
-	// Getters
-	//
-
-	const QString & name()          const { return _name; }
-	int             count()         const { return _count; }
-	FileSize        totalSize()     const { return _totalSize; }
-	float           percentage()    const { return _percentage; }
-
 
     protected:
-
-	/**
-	 * Helper function to set both the column text and alignment.
-	 **/
-	void set( FileTypeColumns col, Qt::Alignment alignment, const QString & text )
-	{
-	    setText( col, text );
-	    setTextAlignment( col, Qt::AlignVCenter | alignment );
-	}
 
 	/**
 	 * Less-than operator for sorting.
@@ -228,13 +206,11 @@ namespace QDirStat
 
     private:
 
-	QString  _name;
 	int      _count;
 	FileSize _totalSize;
 	float    _percentage;
 
-    }; // class FileTypeItem
-
+    };	// class FileTypeItem
 
 
 
@@ -293,8 +269,8 @@ namespace QDirStat
 
 	QString _suffix;
 
-    }; // class SuffixFileTypeItem
+    };	// class SuffixFileTypeItem
 
-} // namespace QDirStat
+}	// namespace QDirStat
 
-#endif // FileTypeStatsWindow_h
+#endif	// FileTypeStatsWindow_h

--- a/src/FilesystemsWindow.h
+++ b/src/FilesystemsWindow.h
@@ -67,7 +67,8 @@ namespace QDirStat
 	 * Convenience function for creating, populating and showing the shared
 	 * instance.
 	 **/
-	static FilesystemsWindow * populateSharedInstance( QWidget * parent );
+	static void populateSharedInstance( QWidget * parent )
+	    { sharedInstance( parent )->populate(); }
 
 
     protected slots:
@@ -128,10 +129,6 @@ namespace QDirStat
 
     private:
 
-	//
-	// Data members
-	//
-
 	std::unique_ptr<Ui::FilesystemsWindow> _ui;
 
     };	// class FilesystemsWindow
@@ -149,23 +146,26 @@ namespace QDirStat
 	FS_UsedSizeCol,
 	FS_ReservedSizeCol,
 	FS_FreeSizeCol,
-	FS_FreePercentCol
+	FS_FreePercentCol,
     };
 
 
+
     /**
-     * Item class for the filesystems list (which is really a tree widget).
+     * Item class for the filesystems list.
      **/
     class FilesystemItem: public QTreeWidgetItem
     {
     public:
+
 	/**
 	 * Constructor.
 	 **/
-	FilesystemItem( MountPoint * mountPoint, QTreeWidget * parent );
+	FilesystemItem( MountPoint * mountPoint );
 
-	// Getters
-
+	/**
+	 * Getters for the column values.
+	 **/
 	const QString & device()         const { return _device; }
 	const QString & mountPath()      const { return _mountPath; }
 	const QString & fsType()         const { return _fsType; }
@@ -177,13 +177,8 @@ namespace QDirStat
 	bool            isNetworkMount() const { return _isNetworkMount; }
 	bool            isReadOnly()     const { return _isReadOnly; }
 
-    protected:
 
-	/**
-	 * Set the text and text alignment for a column.
-	 **/
-	void set( int col, Qt::Alignment alignment, const QString & text )
-	    { setText( col, text ); setTextAlignment( col, alignment | Qt::AlignVCenter ); }
+    protected:
 
 	/**
 	 * Less-than operator for sorting.
@@ -203,8 +198,8 @@ namespace QDirStat
 	bool     _isNetworkMount;
 	bool     _isReadOnly;
 
-    }; // class FilesystemItem
+    };	// class FilesystemItem
 
-} // namespace QDirStat
+}	// namespace QDirStat
 
 #endif	// FilesystemsWindow_h

--- a/src/LocateFileTypeWindow.h
+++ b/src/LocateFileTypeWindow.h
@@ -79,17 +79,15 @@ namespace QDirStat
 
 	/**
 	 * Select one of the search results in the main window's tree and
-	 * treemap widgets via their SelectionModel.
+	 * treemap widgets via their SelectionModel.  The actual selection
+	 * is done after a short timeout to avoid blocking the dialog tree
+	 * itself.
 	 **/
-	void selectResult( QTreeWidgetItem * item ) const;
+	void selectResult() const;
+	void selectResults() const;
 
 
     protected:
-
-	/**
-	 * Return the current search suffix with leading '*'.
-	 **/
-	QString displaySuffix() const { return '*' + _suffix; }
 
 	/**
 	 * Populate the window: Locate files with 'suffix' in 'fileInfo'.
@@ -107,14 +105,6 @@ namespace QDirStat
 	void populateRecursive( FileInfo * dir );
 
 	/**
-	 * Select the first item in the list. This will also select it in the
-	 * main window, open the branch where this item is in and scroll the
-	 * main window's tree so that item is visible tere.
-	 **/
-	void selectFirstItem() const
-	    { _ui->treeWidget->setCurrentItem( _ui->treeWidget->topLevelItem( 0 ) ); }
-
-	/**
 	 * Resize event, reimplemented from QWidget.
 	 *
 	 * Elide the title to fit inside the current dialog width, so that
@@ -128,15 +118,12 @@ namespace QDirStat
 
     private:
 
-	//
-	// Data members
-	//
-
 	std::unique_ptr<Ui::LocateFileTypeWindow> _ui;
 
 	Subtree _subtree;
 	QString _suffix;
-    };
+
+    };	// class LocateFileTypeWindow
 
 
     /**
@@ -147,7 +134,7 @@ namespace QDirStat
 	SSR_CountCol = 0,
 	SSR_TotalSizeCol,
 	SSR_PathCol,
-	SSR_ColumnCount
+	SSR_ColumnCount,
     };
 
 
@@ -191,15 +178,6 @@ namespace QDirStat
     protected:
 
 	/**
-	 * Set both the text and text alignment for a column.
-	 **/
-	void set( int col, const QString & text, Qt::Alignment alignment )
-	{
-	    setText( col, text );
-	    setTextAlignment( col, alignment | Qt::AlignVCenter );
-	}
-
-	/**
 	 * Less-than operator for sorting.
 	 **/
 	bool operator<( const QTreeWidgetItem & other ) const override;
@@ -211,8 +189,8 @@ namespace QDirStat
 	int      _count;
 	FileSize _totalSize;
 
-    }; // class SuffixSearchResultItem
+    };	// class SuffixSearchResultItem
 
-} // namespace QDirStat
+}	// namespace QDirStat
 
-#endif // LocateFileTypeWindow_h
+#endif	// LocateFileTypeWindow_h

--- a/src/LocateFilesWindow.cpp
+++ b/src/LocateFilesWindow.cpp
@@ -77,13 +77,17 @@ namespace
     {
 	app()->dirTreeModel()->setTreeWidgetSizes( tree );
 
-	const QString size     = QObject::tr( "Total Size" );
-	const QString modified = QObject::tr( "Last Modified" );
-	const QString path     = QObject::tr( "Path" );
-	tree->setHeaderLabels( { size, modified, path } );
-	tree->header()->setDefaultAlignment( Qt::AlignHCenter | Qt::AlignVCenter );
-	tree->headerItem()->setTextAlignment( LocateListPathCol, Qt::AlignLeft | Qt::AlignVCenter);
-	tree->header()->setSectionResizeMode( QHeaderView::ResizeToContents );
+	QTreeWidgetItem * headerItem = tree->headerItem();
+	headerItem->setText( LL_SizeCol,  QObject::tr( "Total Size" ) );
+	headerItem->setText( LL_MTimeCol, QObject::tr( "Last Modified" ) );
+	headerItem->setText( LL_PathCol,  QObject::tr( "Path" ) );
+	headerItem->setTextAlignment( LL_PathCol, Qt::AlignLeft | Qt::AlignVCenter);
+
+	QHeaderView * header = tree->header();
+	header->setDefaultAlignment( Qt::AlignHCenter | Qt::AlignVCenter );
+	header->setSectionResizeMode( QHeaderView::ResizeToContents );
+
+	// The tree will be sorted each time populateSharedInstance() is called
     }
 
 } // namespace
@@ -110,11 +114,12 @@ LocateFilesWindow::LocateFilesWindow( TreeWalker * treeWalker,
     connect( _ui->refreshButton, &QPushButton::clicked,
              this,               &LocateFilesWindow::refresh );
 
-    connect( _ui->treeWidget,    &QTreeWidget::currentItemChanged,
-             this,               &locateInMainWindow );
-
     connect( _ui->treeWidget,    &QTreeWidget::customContextMenuRequested,
              this,               &LocateFilesWindow::itemContextMenu );
+
+    connect( _ui->treeWidget, &QTreeWidget::currentItemChanged, &locateInMainWindow );
+
+    show();
 }
 
 
@@ -142,7 +147,6 @@ LocateFilesWindow * LocateFilesWindow::sharedInstance( TreeWalker * treeWalker )
 void LocateFilesWindow::refresh()
 {
     populate( _subtree() );
-    selectFirstItem();
 }
 
 
@@ -158,13 +162,11 @@ void LocateFilesWindow::populateSharedInstance( TreeWalker    * treeWalker,
     // Get the shared instance, creating it if necessary
     LocateFilesWindow * instance = sharedInstance( treeWalker );
 
+    // Set the heading and sort order for each new populate command
+    instance->_ui->treeWidget->sortByColumn( sortCol, sortOrder );
     instance->_ui->heading->setStatusTip( headingText );
     instance->populate( fileInfo );
-    instance->_ui->treeWidget->sortByColumn( sortCol, sortOrder );
-    instance->show();
-
-    // Select the first row after a delay so it doesn't slow down displaying the list
-    QTimer::singleShot( 25, instance, &LocateFilesWindow::selectFirstItem );
+    instance->raise();
 }
 
 
@@ -172,20 +174,20 @@ void LocateFilesWindow::populate( FileInfo * fileInfo )
 {
     // logDebug() << "populating with " << fileInfo << Qt::endl;
 
+    _ui->treeWidget->clear();
+
     _subtree = fileInfo;
     _treeWalker->prepare( _subtree() );
 
-    // For better Performance: Disable sorting while inserting many items
-    _ui->treeWidget->setSortingEnabled( false );
-    _ui->treeWidget->clear();
-
-    populateRecursive( fileInfo ? fileInfo : _subtree() );
+    populateRecursive( fileInfo );
     showResultsCount( _ui->treeWidget->topLevelItemCount(), _treeWalker->overflow(), _ui->resultsLabel );
-
-    _ui->treeWidget->setSortingEnabled( true );
 
     // Force a redraw of the header from the status tip
     resizeEvent( nullptr );
+
+    // Select the first row after a delay so it (and its signals) doesn't slow down the list showing
+    QTimer::singleShot( 50, this, [ this ]()
+	{ _ui->treeWidget->setCurrentItem( _ui->treeWidget->topLevelItem( 0 ) ); } );
 }
 
 
@@ -220,8 +222,15 @@ void LocateFilesWindow::itemContextMenu( const QPoint & pos )
 void LocateFilesWindow::resizeEvent( QResizeEvent * )
 {
     // Format the heading with the current url, which may be a fallback
-    const FileInfo * fileInfo = _subtree();
-    const QString heading = _ui->heading->statusTip().arg( fileInfo ? fileInfo->url() : QString{} );
+    const QString heading = [ this ]()
+    {
+	const QString statusTip = _ui->heading->statusTip();
+	if ( statusTip.isEmpty() )
+	    return QString{};
+
+	const FileInfo * fileInfo = _subtree();
+	return statusTip.arg( fileInfo ? fileInfo->url() : QString{} );
+    }();
 
     // Calculate a width from the dialog less margins, less a bit more
     elideLabel( _ui->heading, heading, size().width() - 24 );
@@ -231,19 +240,25 @@ void LocateFilesWindow::resizeEvent( QResizeEvent * )
 
 
 LocateListItem::LocateListItem( FileInfo * item ):
-    QTreeWidgetItem{ QTreeWidgetItem::UserType }
+    QTreeWidgetItem{},
+    _size{ item->totalSize() },
+    _mtime{ item->mtime() },
+    _path{ item->url() }
 {
-    CHECK_PTR( item );
+    /**
+     * Helper function to set the text and text alignment for a column.
+     **/
+    const auto set = [ this ]( int col, Qt::Alignment alignment, const QString & text )
+    {
+	setText( col, text );
+	setTextAlignment( col, alignment | Qt::AlignVCenter );
+    };
 
-    _path  = item->url();
-    _size  = item->totalSize();
-    _mtime = item->mtime();
+    set( LL_SizeCol,  Qt::AlignRight,   formatSize( _size ) );
+    set( LL_MTimeCol, Qt::AlignHCenter, formatTime( _mtime ) );
+    set( LL_PathCol,  Qt::AlignLeft,    _path );
 
-    set( LocateListSizeCol,  formatSize( _size ),  Qt::AlignRight   );
-    set( LocateListMTimeCol, formatTime( _mtime ), Qt::AlignHCenter );
-    set( LocateListPathCol,  _path,                Qt::AlignLeft    );
-
-    setIcon( LocateListPathCol, app()->dirTreeModel()->itemTypeIcon( item ) );
+    setIcon( LL_PathCol, app()->dirTreeModel()->itemTypeIcon( item ) );
 }
 
 
@@ -257,16 +272,13 @@ bool LocateListItem::operator<( const QTreeWidgetItem & rawOther ) const
     // error which should not be silently ignored.
     const LocateListItem & other = dynamic_cast<const LocateListItem &>( rawOther );
 
-    switch ( static_cast<LocateListColumns>( treeWidget()->sortColumn() ) )
+    switch ( treeWidget()->sortColumn() )
     {
-	case LocateListSizeCol:  return _size  < other.size();
-	case LocateListMTimeCol: return _mtime < other.mtime();
-
-	case LocateListPathCol:
-	case LocateListColumnCount:
-	    break;
+	case LL_SizeCol:  return _size  < other.size();
+	case LL_MTimeCol: return _mtime < other.mtime();
+	default:                 return QTreeWidgetItem::operator<( rawOther );
     }
 
-    return QTreeWidgetItem::operator<( rawOther );
+
 }
 

--- a/src/LocateFilesWindow.h
+++ b/src/LocateFilesWindow.h
@@ -114,25 +114,6 @@ namespace QDirStat
 	void populate( FileInfo * fileInfo );
 
 	/**
-	 * Set the sort column and sort order (Qt::AscendingOrder or
-	 * Qt::DescendingOrder), sort the list and select the first item.
-	 **/
-//	void sortByColumn( int col, Qt::SortOrder order );
-
-	/**
-	 * Count the number of items in the list and display the number.
-	 **/
-//	void showResultsCount() const;
-
-	/**
-	 * Select the first item in the list. This will also select it in the
-	 * main window, open the branch where this item is in and scroll the
-	 * main window's tree so that item is visible tere.
-	 **/
-	void selectFirstItem() const
-	    { _ui->treeWidget->setCurrentItem( _ui->treeWidget->topLevelItem( 0 ) ); }
-
-	/**
 	 * Recursively locate directories that contain files matching the
 	 * search suffix and create a search result item for each one.
 	 **/
@@ -152,15 +133,12 @@ namespace QDirStat
 
     private:
 
-	//
-	// Data members
-	//
-
 	std::unique_ptr<Ui::LocateFilesWindow> _ui;
 
 	std::unique_ptr<TreeWalker> _treeWalker;
 	Subtree                     _subtree;
-    };
+
+    };	// class LocateFilesWindow
 
 
     /**
@@ -168,16 +146,15 @@ namespace QDirStat
      **/
     enum LocateListColumns
     {
-	LocateListSizeCol,
-	LocateListMTimeCol,
-	LocateListPathCol,
-	LocateListColumnCount
+	LL_SizeCol,
+	LL_MTimeCol,
+	LL_PathCol,
+	LL_ColumnCount,
     };
 
 
     /**
-     * Item class for the locate list (which is really a tree widget),
-     * representing one file with its path.
+     * Item class for the locate list, representing one file with its path.
      *
      * This item intentionally does not store a FileInfo or DirInfo pointer
      * for each search result, but its path. This is more expensive to store,
@@ -205,21 +182,12 @@ namespace QDirStat
 	/**
 	 * Getters for the item properties.
 	 **/
-	const QString & path()  const { return _path;  }
 	FileSize        size()  const { return _size;  }
 	time_t          mtime() const { return _mtime; }
+	const QString & path()  const { return _path;  }
 
 
     protected:
-
-	/**
-	 * Sets both the text and text alignment for a column.
-	 **/
-	void set( int col, const QString & text, Qt::Alignment alignment )
-	{
-	    setText( col, text );
-	    setTextAlignment( col, alignment | Qt::AlignVCenter );
-	}
 
 	/**
 	 * Less-than operator for sorting.
@@ -229,12 +197,12 @@ namespace QDirStat
 
     private:
 
-	QString  _path;
 	FileSize _size;
 	time_t   _mtime;
+	QString  _path;
 
-    }; // class LocateListItem
+    };	// class LocateListItem
 
-} // namespace QDirStat
+}	// namespace QDirStat
 
 #endif // LocateFilesWindow_h

--- a/src/UnreadableDirsWindow.h
+++ b/src/UnreadableDirsWindow.h
@@ -26,6 +26,16 @@ namespace QDirStat
     class FileTypeStats;
     class MimeCategory;
 
+    enum UnreadableDirectories
+    {
+	UD_PathCol,
+	UD_UserCol,
+	UD_GroupCol,
+	UD_PermCol,
+	UD_OctalCol,
+    };
+
+
     /**
      * Modeless dialog to display directories that could not be read when
      * reading a directory tree.
@@ -84,115 +94,36 @@ namespace QDirStat
 	 * Convenience function for creating, populating and showing the shared
 	 * instance.
 	 **/
-	static void populateSharedInstance( FileInfo * fileInfo );
+	static void populateSharedInstance()
+	    { sharedInstance()->populate(); }
+
+
+    protected slots:
 
 	/**
-	 * Obtain the subtree from the last used URL or 0 if none was found.
+	 * Populate the window: locate unreadable directories.
+	 *
+	 * This clears the old search results first, then searches from
+	 * the top level of the directory tree.
 	 **/
-//	const Subtree & subtree() const { return _subtree; }
+	void populate();
 
 
     protected:
-
-	/**
-	 * Populate the window: Locate unreadable directories.
-	 *
-	 * This clears the old search results first, then searches the subtree
-	 * and populates the search result list with the directories could not
-	 * be read.
-	 **/
-	void populate( FileInfo * fileInfo );
 
 	/**
 	 * Recursively find unreadable directories in a subtree and add an
 	 * entry to the tree widget for each one.
 	 **/
-	void populateRecursive( FileInfo * fileInfo );
+	void populateRecursive( FileInfo * subtree );
 
 
     private:
-
-	//
-	// Data members
-	//
 
 	std::unique_ptr<Ui::UnreadableDirsWindow> _ui;
 
-	Subtree _subtree;
+    };	// class UnreadableDirsWindow
 
-    };
+}	// namespace QDirStat
 
-
-
-    /**
-     * Item class for the directory list (which is really a tree widget),
-     * representing one directory that could not be read.
-     *
-     * This item intentionally does not store a FileInfo or DirInfo pointer
-     * for each search result, but its path. This is more expensive to
-     * store, and the corresponding DirInfo * has to be fetched again with
-     * DirTree::locate() (which is an expensive operation), but it is a lot
-     * safer in case the tree is modified, i.e. if the user starts cleanup
-     * operations or refreshes the tree from disk. Not only are no pointers
-     * stored that might become invalid, but the search result remains valid
-     * even after such an operation since the strings (the paths) will still
-     * match an object in the tree in most cases.
-     *
-     * In the worst case, the search result won't find the corresponding
-     * DirInfo * anymore (if that directory branch was deleted), but for sure
-     * it will not crash.
-     **/
-
-    enum UnreadableDirectories
-    {
-	UD_Path,
-	UD_User,
-	UD_Group,
-	UD_Permissions,
-	UD_Octal
-    };
-
-    class UnreadableDirListItem: public QTreeWidgetItem
-    {
-    public:
-
-	/**
-	 * Constructor.
-	 **/
-	UnreadableDirListItem( DirInfo * dir );
-
-	/**
-	 * Return the directory object for this item.
-	 **/
-	DirInfo * dir() const { return _dir; }
-
-
-    protected:
-
-	/**
-	 * Set the text and alignment for a column.
-	 **/
-	void set( UnreadableDirectories col, const QString & text, Qt::Alignment alignment )
-	{
-	    setText( col, text );
-	    setTextAlignment( col, alignment | Qt::AlignVCenter );
-	}
-
-	/**
-	 * Less-than operator for sorting.
-	 *
-	 * Currently, all columns sort by their text value, so this override
-	 * is not required.
-	 **/
-//	bool operator<( const QTreeWidgetItem & other ) const override;
-
-
-    private:
-
-	DirInfo * _dir;
-
-    }; // class UnreadableDirListItem
-
-} // namespace QDirStat
-
-#endif // UnreadableDirsWindow_h
+#endif	// UnreadableDirsWindow_h


### PR DESCRIPTION
Reorganise the dialogs with tree widgets for more consistency.
Make the column enum names more consistent, with an acronym, underscore, name, and ending in "Col".
Construct the headers using the column enums instead of a blind list.
Make the initTree() functions virtual carbon-copies of eachother.
Sort in the constructor (except LocateFilesWindow, which uses a different sort order for each type of search) and don't subsequently override any user sorts.
Simplify the item derived classes, including dropping the UnreadableDirListItem completely as it adds nothing.
Add a refresh button to UnreadableDirsWindow: the windo can handle directories disappearing from the main tree, but it is nice to be able to keep them consistent.
Simplify and inline many of the populateSharedInstnce() functions.
A