### PR TITLE
Dialogs with trees

### DIFF
--- a/src/FileAgeStatsWindow.h
+++ b/src/FileAgeStatsWindow.h
@@ -116,12 +116,6 @@ namespace QDirStat
 	void populate( FileInfo * fileInfo );
 
 	/**
-	 * Return the currently selected item in the tree widget or 0
-	 * if there is none or if it is the wrong type.
-	 **/
-	const YearListItem * selectedItem() const;
-
-	/**
 	 * Key press event for detecting enter/return.
 	 *
 	 * Reimplemented from QWidget.
@@ -154,7 +148,7 @@ namespace QDirStat
      **/
     enum YearListColumns
     {
-	YL_YearCol,
+	YL_YearMonthCol,
 	YL_FilesCountCol,
 	YL_FilesPercentBarCol,
 	YL_FilesPercentCol,
@@ -176,7 +170,7 @@ namespace QDirStat
 	/**
 	 * Constructor.
 	 **/
-	YearListItem( const YearStats & yearStats, bool enabled );
+	YearListItem( const YearStats & yearStats );
 
 	/**
 	 * Return the year for this item.

--- a/src/LocateFilesWindow.cpp
+++ b/src/LocateFilesWindow.cpp
@@ -34,11 +34,11 @@ namespace
     void showResultsCount( int results, bool overflow, QLabel * label )
     {
 	if ( overflow )
-	    label->setText( QObject::tr( "Limited to %1 results" ).arg( results ) );
+	    label->setText( QObject::tr( "Limited to %L1 results" ).arg( results ) );
 	else if ( results == 1 )
 	    label->setText( QObject::tr( "1 result" ) );
 	else
-	    label->setText( QObject::tr( "%1 results" ).arg( results ) );
+	    label->setText( QObject::tr( "%L1 results" ).arg( results ) );
     }
 
 
@@ -240,7 +240,7 @@ void LocateFilesWindow::resizeEvent( QResizeEvent * )
 
 
 LocateListItem::LocateListItem( FileInfo * item ):
-    QTreeWidgetItem{},
+    QTreeWidgetItem{ UserType },
     _size{ item->totalSize() },
     _mtime{ item->mtime() },
     _path{ item->url() }

--- a/src/UnreadableDirsWindow.cpp
+++ b/src/UnreadableDirsWindow.cpp
@@ -117,7 +117,7 @@ void UnreadableDirsWindow::populate()
     populateRecursive( app()->firstToplevel() );
 
     const int rowCount = _ui->treeWidget->topLevelItemCount();
-    _ui->totalLabel->setText( rowCount > 1 ? tr( "%1 directories" ).arg( rowCount ) : QString{} );
+    _ui->totalLabel->setText( rowCount > 1 ? tr( "%L1 directories" ).arg( rowCount ) : QString{} );
 
     //logDebug() << rowCount << " directories" << Qt::endl;
 
@@ -134,7 +134,7 @@ void UnreadableDirsWindow::populateRecursive( FileInfo * subtree )
     DirInfo * dir = subtree->toDirInfo();
     if ( dir->readError() )
     {
-	QTreeWidgetItem * item = new QTreeWidgetItem{ _ui->treeWidget };
+	QTreeWidgetItem * item = new QTreeWidgetItem{ _ui->treeWidget, QTreeWidgetItem::UserType };
 
 	const auto set = [ item ]( UnreadableDirectories col, Qt::Alignment alignment, const QString & text )
 	{
@@ -158,41 +158,3 @@ void UnreadableDirsWindow::populateRecursive( FileInfo * subtree )
     // Dot entries can't contain unreadable dirs, but attics can
     populateRecursive( dir->attic() );
 }
-
-
-
-/*
-UnreadableDirListItem::UnreadableDirListItem( DirInfo * dir ) :
-    QTreeWidgetItem{ QTreeWidgetItem::UserType },
-    _dir{ dir }
-{
-    set( UD_Path,        dir->url(),                 Qt::AlignLeft  );
-    set( UD_User,        dir->userName(),            Qt::AlignLeft  );
-    set( UD_Group,       dir->groupName(),           Qt::AlignLeft  );
-    set( UD_Permissions, dir->symbolicPermissions(), Qt::AlignRight );
-    set( UD_Octal,       dir->octalPermissions(),    Qt::AlignRight );
-
-    setIcon( UD_Path, app()->dirTreeModel()->unreadableDirIcon() );
-}
-*/
-/*
-bool UnreadableDirListItem::operator<( const QTreeWidgetItem & rawOther ) const
-{
-    if ( !treeWidget() )
-	return QTreeWidgetItem::operator<( rawOther );
-
-    // Since this is a reference, the dynamic_cast will throw a std::bad_cast
-    // exception if it fails. Not catching this here since this is a genuine
-    // error which should not be silently ignored.
-    const UnreadableDirListItem & other = dynamic_cast<const UnreadableDirListItem &>( rawOther );
-
-    switch ( treeWidget()->sortColumn() )
-    {
-	case UD_Path: break;
-	case UD_User:        return _dir->userName()            < other._dir->userName();
-	case UD_Group:       return _dir->groupName()           < other._dir->groupName();
-	case UD_Permissions: return _dir->symbolicPermissions() < other._dir->symbolicPermissions();
-	case UD_Octal:       return _dir->octalPermissions()    < other._dir->octalPermissions();
-	default:             return QTreeWidgetItem::operator<( rawOther );
-}
-*/

--- a/src/file-type-stats-window.ui
+++ b/src/file-type-stats-window.ui
@@ -151,5 +151,53 @@
     </hint>
    </hints>
   </connection>
+  <connection>
+   <sender>actionLocate</sender>
+   <signal>triggered()</signal>
+   <receiver>locateButton</receiver>
+   <slot>click()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>-1</x>
+     <y>-1</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>159</x>
+     <y>316</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>actionSizeStats</sender>
+   <signal>triggered()</signal>
+   <receiver>sizeStatsButton</receiver>
+   <slot>click()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>-1</x>
+     <y>-1</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>266</x>
+     <y>316</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>treeWidget</sender>
+   <signal>itemActivated(QTreeWidgetItem*,int)</signal>
+   <receiver>locateButton</receiver>
+   <slot>click()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>338</x>
+     <y>161</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>159</x>
+     <y>316</y>
+    </hint>
+   </hints>
+  </connection>
  </connections>
 </ui>

--- a/src/filesystems-window.ui
+++ b/src/filesystems-window.ui
@@ -163,5 +163,37 @@
     </hint>
    </hints>
   </connection>
+  <connection>
+   <sender>fsTree</sender>
+   <signal>itemActivated(QTreeWidgetItem*,int)</signal>
+   <receiver>readButton</receiver>
+   <slot>click()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>371</x>
+     <y>169</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>141</x>
+     <y>328</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>actionRead</sender>
+   <signal>triggered()</signal>
+   <receiver>readButton</receiver>
+   <slot>click()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>-1</x>
+     <y>-1</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>141</x>
+     <y>328</y>
+    </hint>
+   </hints>
+  </connection>
  </connections>
 </ui>

--- a/src/locate-file-type-window.ui
+++ b/src/locate-file-type-window.ui
@@ -32,6 +32,9 @@
      <property name="uniformRowHeights">
       <bool>true</bool>
      </property>
+     <property name="sortingEnabled">
+      <bool>true</bool>
+     </property>
      <column>
       <property name="text">
        <string notr="true">1</string>

--- a/src/locate-files-window.ui
+++ b/src/locate-files-window.ui
@@ -35,6 +35,9 @@
      <property name="uniformRowHeights">
       <bool>true</bool>
      </property>
+     <property name="sortingEnabled">
+      <bool>true</bool>
+     </property>
      <column>
       <property name="text">
        <string notr="true">1</string>
@@ -59,12 +62,6 @@
      </item>
      <item>
       <widget class="QLabel" name="resultsLabel">
-       <property name="sizePolicy">
-        <sizepolicy hsizetype="MinimumExpanding" vsizetype="Preferred">
-         <horstretch>0</horstretch>
-         <verstretch>0</verstretch>
-        </sizepolicy>
-       </property>
        <property name="text">
         <string>42 results</string>
        </property>


### PR DESCRIPTION
Use QTreeWidgetItem::type instead of some dynamic casting.
Use the activated signal instead of doubleClicked for better platform compatibility.  Improve (or make worse?) keyboard navigation in FileAgeStatsWindow; enter key now just locates for a year and doesn't expand.
Link actions to buttons in the ui file where applicable.
Localise some more numbers that may be more than 999.