### PR TITLE
Stats dialog updates

### DIFF
--- a/src/FileAgeStats.cpp
+++ b/src/FileAgeStats.cpp
@@ -28,8 +28,8 @@ FileAgeStats::FileAgeStats( const FileInfo * subtree ):
     initMonthStats( lastYear() );
 
     collectRecursive( subtree );
-    calcPercentages();
-    collectYears();
+//    calcPercentages();
+//    collectYears();
 }
 
 
@@ -62,25 +62,27 @@ void FileAgeStats::collectRecursive( const FileInfo * dir )
 
             YearStats & yearStats = _yearStats[ year ];
             yearStats.year = year;
-            ++yearStats.filesCount;
+            ++yearStats.count;
+            ++_totalCount;
             yearStats.size += item->size();
+            _totalSize += item->size();
 
             YearStats * thisMonthStats = monthStats( year, month );
             if ( thisMonthStats )
             {
-                ++thisMonthStats->filesCount;
+                ++thisMonthStats->count;
                 thisMonthStats->size += item->size();
             }
         }
     }
 }
 
-
+/*
 void FileAgeStats::calcPercentages()
 {
     // Sum up the totals over all years
-    int      totalFilesCount = 0;
-    FileSize totalFilesSize  = 0LL;
+    FileCount totalFilesCount = 0;
+    FileSize  totalFilesSize  = 0LL;
 
     for ( const YearStats & stats : asConst( _yearStats ) )
     {
@@ -108,7 +110,7 @@ void FileAgeStats::calcMonthPercentages( short year )
     if ( !thisYearStats )
         return;
 
-    for ( int month = 1; month <= 12; month++ )
+    for ( short month = 1; month <= 12; month++ )
     {
         YearStats * stats = monthStats( year, month );
         if ( stats )
@@ -121,14 +123,14 @@ void FileAgeStats::calcMonthPercentages( short year )
         }
     }
 }
-
-
+*/
+/*
 void FileAgeStats::collectYears()
 {
     _yearsList = _yearStats.keys();
     std::sort( _yearsList.begin(), _yearsList.end() );
 }
-
+*/
 
 YearStats * FileAgeStats::monthStats( short year, short month )
 {

--- a/src/FileAgeStats.h
+++ b/src/FileAgeStats.h
@@ -25,16 +25,14 @@ namespace QDirStat
 
 
     /**
-     * File modification year / month statistics for one year or one month.
+     * File count and size statistics for one year or one month.
      **/
     struct YearStats
     {
-        short    year;                     // 1970 (time_t 0 seconds) - 32767
-        short    month;                    // 1-12 or 0 for the complete year
-        float    filesPercent{ 0.0f };     // 0.0 .. 100.0
-        int      filesCount{ 0 };
-        float    sizePercent{ 0.0f };      // 0.0 .. 100.0
-        FileSize size{ 0LL };
+        short     year;                     // 1970 (time_t 0 seconds) - 32767
+        short     month;                    // 1-12 or 0 for the complete year
+        FileCount count{ 0 };
+        FileSize  size{ 0 };
 
         YearStats( short yr = 0, short mn = 0 ):
             year{ yr },
@@ -61,7 +59,7 @@ namespace QDirStat
          * Return a sorted list of the years where files with that modification
          * year were found after collecting data.
          **/
-        const YearsList & years() const { return _yearsList; }
+        YearsList years() const { return _yearStats.keys(); }
 
         /**
          * Return year statistics for the specified year or 0 if there are
@@ -101,6 +99,14 @@ namespace QDirStat
          **/
         short lastYear() const { return _thisYear - 1; }
 
+        /**
+         * Return the percentage of 'count' or 'size' wrt the total.
+         **/
+        float countPercent( FileCount count ) const
+            { return _totalCount == 0 ? 0.0 : 100.0f * count / _totalCount; }
+        float sizePercent( FileSize size ) const
+            { return _totalSize == 0 ? 0.0 : 100.0f * size / _totalSize; }
+
 
     protected:
 
@@ -119,30 +125,32 @@ namespace QDirStat
          * Sum up the totals over all years and calculate the percentages for
          * each year
          **/
-        void calcPercentages();
+//        void calcPercentages();
 
         /**
          * Calculate the monthly percentages for all 12 months in one year.
          **/
-        void calcMonthPercentages( short year );
+//        void calcMonthPercentages( short year );
 
         /**
          * Fill the _yearsList with all the years in the _yearStats hash and
          * sort the list.
          **/
-        void collectYears();
+//        void collectYears();
 
 
     private:
 
         YearStatsHash   _yearStats;
-        YearsList       _yearsList;
 
         YearStats       _thisYearMonthStats[ 12 ];
         YearStats       _lastYearMonthStats[ 12 ];
 
         short           _thisYear;
         short           _thisMonth;
+
+        FileCount       _totalCount{ 0 };
+        FileSize        _totalSize{ 0 };
 
     };  // class FileAgesStats
 

--- a/src/FileAgeStatsWindow.h
+++ b/src/FileAgeStatsWindow.h
@@ -101,6 +101,11 @@ namespace QDirStat
 	void locateFiles();
 
 	/**
+	 * 'item' was activated by mouse or keyboard.
+	 **/
+	void itemActivated( QTreeWidgetItem * item, int );
+
+	/**
 	 * Enable or disable actions and buttons depending on the internal
 	 * state, e.g. if any item is selected and the number of files for the
 	 * selected year are in the specified range (1..10000).
@@ -170,7 +175,20 @@ namespace QDirStat
 	/**
 	 * Constructor.
 	 **/
-	YearListItem( const YearStats & yearStats );
+	YearListItem( short     year,
+	              short     month,
+	              FileCount count,
+	              float     countPercent,
+	              FileSize  size,
+	              float     sizePercent );
+
+	/**
+	 * Constructor with just a year.  This will create a disabled
+	 * item with no counts.
+	 **/
+	YearListItem( short year ):
+	    YearListItem{ year, 0, 0, 0, 0, 0 }
+	{}
 
 	/**
 	 * Return the year for this item.
@@ -185,7 +203,7 @@ namespace QDirStat
 	/**
 	 * Return the files count for this item.
 	 **/
-	int filesCount() const { return _filesCount; }
+	int count() const { return _count; }
 
 
     protected:
@@ -200,10 +218,10 @@ namespace QDirStat
 
     private:
 
-	short    _year;
-	short    _month;
-	int      _filesCount;
-	FileSize _size;
+	short     _year;
+	short     _month;
+	FileCount _count;
+	FileSize  _size;
 
     };	// class YearListItem
 

--- a/src/FileSizeStatsModels.cpp
+++ b/src/FileSizeStatsModels.cpp
@@ -21,8 +21,8 @@ using namespace QDirStat;
 namespace
 {
     /**
-     * Return text showing the exact size 'size; in bytes, formatted
-     * according to the local locale style.
+     * Return text showing the exact size 'size' in bytes, formatted
+     * according to the locale style.
      **/
     QString sizeTooltip( FileSize size )
     {

--- a/src/FileSizeStatsWindow.cpp
+++ b/src/FileSizeStatsWindow.cpp
@@ -7,15 +7,15 @@
  *              Ian Nartowicz
  */
 
+#include <QActionGroup>
 #include <QCommandLinkButton>
+#include <QContextMenuEvent>
 #include <QDesktopServices>
 #include <QMenu>
 #include <QPointer>
-#include <QTableWidget>
-#include <QTableWidgetItem>
-#include <QUrl>
 
 #include "FileSizeStatsWindow.h"
+#include "ActionManager.h"
 #include "FileInfo.h"
 #include "FileSizeStats.h"
 #include "FileSizeStatsModels.h"
@@ -48,27 +48,6 @@ namespace
     BucketsTableModel * bucketsTableModel( const QTableView * bucketsTable )
     {
 	return qobject_cast<BucketsTableModel *>( bucketsTable->model() );
-    }
-
-
-    /**
-     * Read hotkey settings and apply to the existing actions found
-     * within 'tree'.  The ui file hotkeys are used as default values.
-     **/
-    void readHotkeySettings( QWidget * tree )
-    {
-	Settings settings;
-
-	settings.beginGroup( "FileSizeStatsWindow" );
-
-	const auto actions = tree->findChildren<QAction *>( nullptr, Qt::FindDirectChildrenOnly );
-	for ( QAction * action : actions )
-	{
-	    tree->addAction( action );
-	    settings.applyActionHotkey( action );
-	}
-
-	settings.endGroup();
     }
 
 
@@ -153,7 +132,7 @@ FileSizeStatsWindow::FileSizeStatsWindow( QWidget * parent ):
     connectActions();
 
     Settings::readWindowSettings( this, "FileSizeStatsWindow" );
-    readHotkeySettings( this );
+    ActionManager::actionHotkeys( this, "FileSizeStatsWindow" );
 
     show();
 }

--- a/src/FileSizeStatsWindow.h
+++ b/src/FileSizeStatsWindow.h
@@ -12,8 +12,6 @@
 
 #include <memory>
 
-#include <QActionGroup>
-#include <QContextMenuEvent>
 #include <QDialog>
 
 #include "ui_file-size-stats-window.h"

--- a/src/FileTypeStats.h
+++ b/src/FileTypeStats.h
@@ -24,21 +24,21 @@ namespace QDirStat
     class MimeCategory;
 
     /**
-     * SuffixCategory and CountSum are defined instead of using
+     * SuffixCategory and CountSize are defined instead of using
      * QPair for the hash keys and values.  This just means that
      * the pair members can be referred to by name rather than
      * simply 'first' and 'second'.
      **/
     struct SuffixCategory
     {
-	QString suffix;
+	QString              suffix;
 	const MimeCategory * category;
     };
 
-    struct CountSum
+    struct CountSize
     {
-	int count;
-	FileSize sum;
+	FileCount count;
+	FileSize  size;
     };
 
     /**
@@ -60,8 +60,8 @@ namespace QDirStat
      * aggregated at the category level; SuffixMap is used for
      * statistics aggregated by suffix per category.
      **/
-    typedef QHash<const MimeCategory *, CountSum> CategoryMap;
-    typedef QHash<SuffixCategory, CountSum>       SuffixMap;
+    typedef QHash<const MimeCategory *, CountSize> CategoryMap;
+    typedef QHash<SuffixCategory, CountSize>       SuffixMap;
 
 
     /**
@@ -99,10 +99,13 @@ namespace QDirStat
 	const MimeCategory * otherCategory() const { return _otherCategory.get(); }
 
 	/**
-	 * Return the percentage of 'size' relative to the tree total size.
+	 * Return the percentage of 'size' or 'count' relative to the subtree
+	 * total.
 	 **/
-	float percentage( FileSize size ) const
-	    { return _totalSize == 0LL ? 0.0f : 100.0f * size / _totalSize; }
+	float countPercent( FileCount count ) const
+	    { return _totalCount == 0 ? 0.0f : 100.0f * count / _totalCount; }
+	float sizePercent( FileSize size ) const
+	    { return _totalSize == 0 ? 0.0f : 100.0f * size / _totalSize; }
 
 
     protected:
@@ -118,8 +121,8 @@ namespace QDirStat
 	/**
 	 * Aaggregate entries to each of the maps.
 	 **/
-	void addCategorySum( const MimeCategory * category, const FileInfo * item );
-	void addSuffixSum  ( const QString & suffix, const MimeCategory * category, const FileInfo * item );
+	void addCategoryItem( const MimeCategory * category, const FileInfo * item );
+	void addSuffixItem  ( const QString & suffix, const MimeCategory * category, const FileInfo * item );
 
 	/**
 	 * Check if the sums add up and how much is unaccounted for.
@@ -137,7 +140,8 @@ namespace QDirStat
 	SuffixMap   _suffixes;
 	CategoryMap _categories;
 
-	FileSize    _totalSize{ 0LL };
+	FileCount   _totalCount{ 0 };
+	FileSize    _totalSize{ 0 };
 
     };	// class FileTypeStats
 

--- a/src/FileTypeStatsWindow.h
+++ b/src/FileTypeStatsWindow.h
@@ -13,7 +13,6 @@
 #include <memory>
 
 #include <QDialog>
-#include <QKeyEvent>
 #include <QTreeWidgetItem>
 
 #include "ui_file-type-stats-window.h"
@@ -101,6 +100,11 @@ namespace QDirStat
 	void sizeStatsForCurrentFileType();
 
 	/**
+	 * 'item' was activated by mouse or keyboard.
+	 **/
+	void itemActivated();
+
+	/**
 	 * Enable or disable the actions depending on the current item.
 	 **/
 	void enableActions();
@@ -112,11 +116,6 @@ namespace QDirStat
 
 
     protected:
-
-	/**
-	 * Read the window and hotkey settings.
-	 **/
-	void readSettings();
 
 	/**
 	 * Populate the widgets for a subtree.
@@ -169,8 +168,9 @@ namespace QDirStat
     {
 	FT_NameCol = 0,
 	FT_CountCol,
+	FT_CountPercentCol,
 	FT_TotalSizeCol,
-	FT_PercentageCol,
+	FT_SizePercentCol,
 	FT_ColumnCount,
     };
 
@@ -185,13 +185,24 @@ namespace QDirStat
 
 	/**
 	 * Constructor. After creating, this item has to be inserted into the
-	 * tree at the appropriate place: Toplevel for categories, below a
+	 * tree at the appropriate place: toplevel for categories, below a
 	 * category for suffixes.
 	 **/
 	FileTypeItem( const QString & name,
-	              int             count,
+	              FileCount       count,
+	              float           countPercent,
 	              FileSize        totalSize,
-	              float           percentage );
+	              float           sizePercent );
+
+	/**
+	 * Return the files count for this category item.
+	 **/
+	FileCount count() const { return _count; }
+
+	/**
+	 * Return the total files size for this category item.
+	 **/
+	FileSize totalSize() const { return _totalSize; }
 
 
     protected:
@@ -206,9 +217,8 @@ namespace QDirStat
 
     private:
 
-	int      _count;
-	FileSize _totalSize;
-	float    _percentage;
+	FileCount _count;
+	FileSize  _totalSize;
 
     };	// class FileTypeItem
 
@@ -226,10 +236,11 @@ namespace QDirStat
 	 **/
 	SuffixFileTypeItem( bool            otherCategory,
 	                    const QString & suffix,
-	                    int             count,
+	                    FileCount       count,
+	                    float           countPercent,
 	                    FileSize        totalSize,
-	                    float           percentage ):
-	    FileTypeItem{ itemName( otherCategory, suffix ), count, totalSize, percentage },
+	                    float           sizePercent ):
+	    FileTypeItem{ itemName( otherCategory, suffix ), count, countPercent, totalSize, sizePercent },
 	    _suffix{ suffix }
 	{}
 

--- a/src/FilesystemsWindow.h
+++ b/src/FilesystemsWindow.h
@@ -84,23 +84,8 @@ namespace QDirStat
 	 **/
 	void readSelectedFilesystem();
 
-	/**
-	 * Copies the device path to the clipboard, trieggered from the context menu.
-	 **/
-	void copyDeviceToClipboard();
-
-	/**
-	 * Custom context menu signalled.
-	 **/
-	void contextMenu( const QPoint & pos );
-
 
     protected:
-
-	/**
-	 * Read the window and hotkey settings.
-	 **/
-	void readSettings();
 
 	/**
 	 * Populate the window with all normal filesystems. Bind mounts,
@@ -118,6 +103,13 @@ namespace QDirStat
 	 * string if there is none.
 	 **/
 	QString selectedPath() const;
+
+	/**
+	 * Copies the currently-selected item column text to the clipboard.
+	 * The full text of the device column is copied, not just the
+	 * visible text.
+	 **/
+	void copyToClipboard();
 
 	/**
 	 * Key press event for detecting evnter/return.

--- a/src/file-age-stats-window.ui
+++ b/src/file-age-stats-window.ui
@@ -35,6 +35,9 @@
      <property name="sortingEnabled">
       <bool>true</bool>
      </property>
+     <property name="expandsOnDoubleClick">
+      <bool>false</bool>
+     </property>
      <attribute name="headerStretchLastSection">
       <bool>false</bool>
      </attribute>
@@ -46,7 +49,7 @@
     </widget>
    </item>
    <item>
-    <layout class="QHBoxLayout" name="horizontalLayout_2" stretch="0,0,1,0">
+    <layout class="QHBoxLayout" name="horizontalLayout_2">
      <property name="spacing">
       <number>12</number>
      </property>
@@ -67,6 +70,9 @@
        </property>
        <property name="text">
         <string>&amp;Locate</string>
+       </property>
+       <property name="default">
+        <bool>true</bool>
        </property>
       </widget>
      </item>

--- a/src/file-type-stats-window.ui
+++ b/src/file-type-stats-window.ui
@@ -35,6 +35,9 @@
      <property name="sortingEnabled">
       <bool>true</bool>
      </property>
+     <property name="expandsOnDoubleClick">
+      <bool>false</bool>
+     </property>
      <attribute name="headerStretchLastSection">
       <bool>false</bool>
      </attribute>
@@ -46,7 +49,7 @@
     </widget>
    </item>
    <item>
-    <layout class="QHBoxLayout" name="horizontalLayout_2" stretch="0,0,1,0">
+    <layout class="QHBoxLayout" name="horizontalLayout_2">
      <property name="spacing">
       <number>12</number>
      </property>
@@ -57,9 +60,6 @@
        </property>
        <property name="text">
         <string>&amp;Refresh</string>
-       </property>
-       <property name="default">
-        <bool>true</bool>
        </property>
       </widget>
      </item>
@@ -75,6 +75,9 @@
          </property>
          <property name="text">
           <string>&amp;Locate by Type</string>
+         </property>
+         <property name="default">
+          <bool>true</bool>
          </property>
         </widget>
        </item>
@@ -119,7 +122,7 @@
     <string>&amp;Locate</string>
    </property>
    <property name="shortcut">
-    <string>Ctrl+L</string>
+    <string>Enter</string>
    </property>
   </action>
   <action name="actionSizeStats">
@@ -152,22 +155,6 @@
    </hints>
   </connection>
   <connection>
-   <sender>actionLocate</sender>
-   <signal>triggered()</signal>
-   <receiver>locateButton</receiver>
-   <slot>click()</slot>
-   <hints>
-    <hint type="sourcelabel">
-     <x>-1</x>
-     <y>-1</y>
-    </hint>
-    <hint type="destinationlabel">
-     <x>159</x>
-     <y>316</y>
-    </hint>
-   </hints>
-  </connection>
-  <connection>
    <sender>actionSizeStats</sender>
    <signal>triggered()</signal>
    <receiver>sizeStatsButton</receiver>
@@ -179,22 +166,6 @@
     </hint>
     <hint type="destinationlabel">
      <x>266</x>
-     <y>316</y>
-    </hint>
-   </hints>
-  </connection>
-  <connection>
-   <sender>treeWidget</sender>
-   <signal>itemActivated(QTreeWidgetItem*,int)</signal>
-   <receiver>locateButton</receiver>
-   <slot>click()</slot>
-   <hints>
-    <hint type="sourcelabel">
-     <x>338</x>
-     <y>161</y>
-    </hint>
-    <hint type="destinationlabel">
-     <x>159</x>
      <y>316</y>
     </hint>
    </hints>

--- a/src/filesystems-window.ui
+++ b/src/filesystems-window.ui
@@ -106,6 +106,9 @@
        <property name="text">
         <string>&amp;Read</string>
        </property>
+       <property name="default">
+        <bool>true</bool>
+       </property>
       </widget>
      </item>
      <item>
@@ -118,30 +121,6 @@
     </layout>
    </item>
   </layout>
-  <action name="actionRead">
-   <property name="icon">
-    <iconset resource="icons.qrc">
-     <normaloff>:/icons/open-dir.png</normaloff>:/icons/open-dir.png</iconset>
-   </property>
-   <property name="text">
-    <string>&amp;Read</string>
-   </property>
-   <property name="shortcut">
-    <string>Ctrl+R</string>
-   </property>
-  </action>
-  <action name="actionCopy">
-   <property name="icon">
-    <iconset resource="icons.qrc">
-     <normaloff>:/icons/edit-copy.png</normaloff>:/icons/edit-copy.png</iconset>
-   </property>
-   <property name="text">
-    <string>&amp;Copy device</string>
-   </property>
-   <property name="shortcut">
-    <string>Ctrl+C</string>
-   </property>
-  </action>
  </widget>
  <resources>
   <include location="icons.qrc"/>
@@ -172,22 +151,6 @@
     <hint type="sourcelabel">
      <x>371</x>
      <y>169</y>
-    </hint>
-    <hint type="destinationlabel">
-     <x>141</x>
-     <y>328</y>
-    </hint>
-   </hints>
-  </connection>
-  <connection>
-   <sender>actionRead</sender>
-   <signal>triggered()</signal>
-   <receiver>readButton</receiver>
-   <slot>click()</slot>
-   <hints>
-    <hint type="sourcelabel">
-     <x>-1</x>
-     <y>-1</y>
     </hint>
     <hint type="destinationlabel">
      <x>141</x>


### PR DESCRIPTION
Make the tree item activation work more consistently.  Make the primary command button the default, mainly for styling purposes.  Capture enter/return key presses and either expand or execute the primary command (read/locate), but not both.  Same for double-click or other item activation triggers.  Enter/return when a button has focus will still activate that button.
Drop the context menu from FilesystemsWindow; it only contained the "activated" action and a custom copy command.  Capture copy key presses (who knew there was an operator== overload for comparing QKeyEvent and QKeySequence::StandardKey!) and copy the whole device string, not just the visible ellipsized string.  FileTypeStatsWindow still has a context menu, with just the locate and size statistics actions; they have somewhat redundant configurable hotkeys and the locate action will always be triggered by the item activation.
Rework FileAgeStats: calculate percentages on the fly since they are only used once; FileCount instead of int; drop the internal (sorted, but that was always unnecessary) year list and the percent data members and replace with getters.
Add a files percent column to FileTypeStatsWindow.  Make the suffix percentages relative to the parent, not the overall total.
